### PR TITLE
Add Brasileirão 2025 table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Felandim.github.io
 my own personal website
+
+## Testes
+
+Para executar a suíte de testes utilize o `pytest`:
+
+```bash
+pytest
+```

--- a/brasileirao_2025.html
+++ b/brasileirao_2025.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brasileirão 2025</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            text-align: center;
+        }
+        table {
+            margin: auto;
+            border-collapse: collapse;
+            width: 80%;
+        }
+        th, td {
+            padding: 8px 12px;
+            border: 1px solid #ddd;
+            text-align: center;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+        tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+    </style>
+</head>
+<body>
+
+<h1>Brasileirão 2025</h1>
+
+<table>
+    <thead>
+        <tr>
+            <th>Classificação</th>
+            <th>PG</th>
+            <th>J</th>
+            <th>V</th>
+            <th>E</th>
+            <th>D</th>
+            <th>GP</th>
+            <th>GC</th>
+            <th>SG</th>
+            <th>%</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td>1° Flamengo</td><td>24</td><td>11</td><td>7</td><td>3</td><td>1</td><td>24</td><td>4</td><td>20</td><td>72</td></tr>
+        <tr><td>2° Cruzeiro</td><td>23</td><td>11</td><td>7</td><td>2</td><td>2</td><td>17</td><td>8</td><td>9</td><td>69</td></tr>
+        <tr><td>3° Bragantino</td><td>23</td><td>11</td><td>7</td><td>2</td><td>2</td><td>14</td><td>8</td><td>6</td><td>69</td></tr>
+        <tr><td>4° Palmeiras</td><td>22</td><td>11</td><td>7</td><td>1</td><td>3</td><td>12</td><td>8</td><td>4</td><td>66</td></tr>
+        <tr><td>5° Fluminense</td><td>20</td><td>11</td><td>6</td><td>2</td><td>3</td><td>15</td><td>12</td><td>3</td><td>60</td></tr>
+        <tr><td>6° Botafogo</td><td>18</td><td>11</td><td>5</td><td>3</td><td>3</td><td>14</td><td>7</td><td>7</td><td>54</td></tr>
+        <tr><td>7° Bahia</td><td>18</td><td>11</td><td>5</td><td>3</td><td>3</td><td>11</td><td>11</td><td>0</td><td>54</td></tr>
+        <tr><td>8° Mirassol</td><td>17</td><td>11</td><td>4</td><td>5</td><td>2</td><td>17</td><td>12</td><td>5</td><td>51</td></tr>
+        <tr><td>9° Atlético-MG</td><td>17</td><td>11</td><td>4</td><td>5</td><td>2</td><td>11</td><td>10</td><td>1</td><td>51</td></tr>
+        <tr><td>10° Ceará</td><td>15</td><td>11</td><td>4</td><td>3</td><td>4</td><td>13</td><td>11</td><td>2</td><td>45</td></tr>
+        <tr><td>11° Corinthians</td><td>15</td><td>11</td><td>4</td><td>3</td><td>4</td><td>12</td><td>14</td><td>-2</td><td>45</td></tr>
+        <tr><td>12° Grêmio</td><td>15</td><td>11</td><td>4</td><td>3</td><td>4</td><td>11</td><td>14</td><td>-3</td><td>45</td></tr>
+        <tr><td>13° São Paulo</td><td>12</td><td>11</td><td>2</td><td>6</td><td>3</td><td>9</td><td>11</td><td>-2</td><td>36</td></tr>
+        <tr><td>14° Internacional</td><td>11</td><td>11</td><td>2</td><td>5</td><td>4</td><td>12</td><td>16</td><td>-4</td><td>33</td></tr>
+        <tr><td>15° Vasco</td><td>10</td><td>11</td><td>3</td><td>1</td><td>7</td><td>11</td><td>15</td><td>-4</td><td>30</td></tr>
+        <tr><td>16° Vitória</td><td>10</td><td>11</td><td>2</td><td>4</td><td>5</td><td>10</td><td>14</td><td>-4</td><td>30</td></tr>
+        <tr><td>17° Fortaleza</td><td>10</td><td>11</td><td>2</td><td>4</td><td>5</td><td>10</td><td>15</td><td>-5</td><td>30</td></tr>
+        <tr><td>18° Santos</td><td>8</td><td>11</td><td>2</td><td>2</td><td>7</td><td>8</td><td>12</td><td>-4</td><td>24</td></tr>
+        <tr><td>19° Juventude</td><td>8</td><td>11</td><td>2</td><td>2</td><td>7</td><td>8</td><td>24</td><td>-16</td><td>24</td></tr>
+        <tr><td>20° Sport</td><td>3</td><td>11</td><td>0</td><td>3</td><td>8</td><td>5</td><td>18</td><td>-13</td><td>9</td></tr>
+    </tbody>
+</table>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
 
   <!-- Inserção do link para a nova página acima do título do dashboard -->
   <p class="link-destaque"><a href="tabela_returno_08_11_2023.html">Clique aqui para ver a tabela do segundo turno do brasileirão!</a></p>
+  <p class="link-destaque"><a href="brasileirao_2025.html">Brasileirão 2025</a></p>
   <h3> atualizado em 08/11/2023 </h3>
   
   <h1>Meu Primeiro Dashboard Hospedado</h1>

--- a/tests/test_html_valid.py
+++ b/tests/test_html_valid.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+from html.parser import HTMLParser
+
+class SimpleHTMLParser(HTMLParser):
+    """Simple parser to ensure HTML can be parsed."""
+    pass
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+
+def discover_html_files():
+    html_files = []
+    for root, _, files in os.walk(REPO_ROOT):
+        for file in files:
+            if file.endswith('.html'):
+                html_files.append(os.path.join(root, file))
+    return html_files
+
+
+@pytest.mark.parametrize('html_file', discover_html_files())
+def test_html_parses(html_file):
+    parser = SimpleHTMLParser()
+    with open(html_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+    try:
+        parser.feed(content)
+    except Exception as exc:
+        pytest.fail(f'Could not parse {html_file}: {exc}')
+
+
+def test_links_in_index_exist():
+    index_path = os.path.join(REPO_ROOT, 'index.html')
+    parser = SimpleHTMLParser()
+    with open(index_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    parser.feed(content)
+    links = []
+    class LinkParser(HTMLParser):
+        def handle_starttag(self, tag, attrs):
+            if tag == 'a':
+                for attr, value in attrs:
+                    if attr == 'href' and value.endswith('.html'):
+                        links.append(value)
+    link_parser = LinkParser()
+    link_parser.feed(content)
+    missing = [link for link in links if not os.path.exists(os.path.join(REPO_ROOT, link))]
+    assert not missing, f'Missing pages referenced in index.html: {missing}'


### PR DESCRIPTION
## Summary
- scrape table data from GE and build new Brasileirão 2025 page
- link new table from the site index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f3beb55c8330a420b99ee264efcf