### PR TITLE
Add about page and fix index layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Felandim.github.io
 my own personal website
 
+Confira a página [Sobre o Site](about.html) para mais informações.
+
 ## Testes
 
 Para executar a suíte de testes utilize o `pytest`:

--- a/about.html
+++ b/about.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Sobre o Site</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <h1>Sobre</h1>
+    <p>Este site reúne alguns projetos pessoais e material de estudo de Felipe Landim.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
             <p class="link-destaque"><a href="brasileirao_2025.html">Brasileirão 2025</a></p>
             <p class="link-destaque"><a href="pato.html">Foto de um Pato</a></p>
             <p class="link-destaque"><a href="meu_primeiro_dash.html">Meu Primeiro Dashboard</a></p>
+            <p class="link-destaque"><a href="about.html">Sobre o Site</a></p>
         </section>
         <section>
             <h2 class="section-title">Estudos prova Seguro Saúde</h2>
@@ -66,9 +67,6 @@
             <p class="link-destaque"><a href="quiz_experiencia.html">Quiz Avaliação de Experiência</a></p>
         </section>
     </main>
-
-
-<main>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix extra `<main>` in `index.html`
- add an `about.html` page
- link the about page from the project list
- mention the new page in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f98eef064833085953ff1171ae8b7