### PR TITLE
Fix Palmeiras Mundial year

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
             <p class="link-destaque"><a href="brasileirao_2025.html">Brasileirão 2025</a></p>
             <p class="link-destaque"><a href="pato.html">Foto de um Pato</a></p>
             <p class="link-destaque"><a href="meu_primeiro_dash.html">Meu Primeiro Dashboard</a></p>
+            <p class="link-destaque"><a href="palmeiras_mundial.html">Palmeiras no Mundial 2025</a></p>
             <p class="link-destaque"><a href="about.html">Sobre o Site</a></p>
         </section>
         <section>

--- a/palmeiras_mundial.html
+++ b/palmeiras_mundial.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Palmeiras no Mundial de Clubes 2025</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            text-align: center;
+        }
+        table {
+            margin: auto;
+            border-collapse: collapse;
+            width: 60%;
+        }
+        th, td {
+            padding: 8px 12px;
+            border: 1px solid #ddd;
+            text-align: center;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+    </style>
+</head>
+<body>
+    <h1>Resultados do Palmeiras no Mundial de Clubes 2025</h1>
+    <p>O Mundial de Clubes de 2025 conta com dezenas de equipes do mundo inteiro. A tabela abaixo traz os resultados do Palmeiras na competição até o momento.</p>
+    <table>
+        <thead>
+            <tr>
+                <th>Data</th>
+                <th>Adversário</th>
+                <th>Placar</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>15/06/2025</td>
+                <td>Porto</td>
+                <td>0 x 0</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update link on the homepage
- fix Palmeiras' Mundial page with correct 2025 date and details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68516a95f0688330a4b53045d522f6aa