### PR TITLE
Add NYC Taxi Tip Histogram example

### DIFF
--- a/docs/nyc_tips/index.html
+++ b/docs/nyc_tips/index.html
@@ -1,0 +1,24 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>NYC Taxi Tip Histogram</title>
+    <script src="https://go-echarts.github.io/go-echarts-assets/assets/echarts.min.js"></script>
+</head>
+
+<body><div class="container">
+    <div class="item" id="HKzRMOHDyPMP" style="width:900px;height:500px;"></div>
+</div><script type="text/javascript">
+    "use strict";
+    let goecharts_HKzRMOHDyPMP = echarts.init(document.getElementById('HKzRMOHDyPMP'), "white", { renderer: "canvas" });
+    let option_HKzRMOHDyPMP = {"color":["#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Gorjetas","type":"bar","data":[{"value":994918},{"value":4749},{"value":215},{"value":57},{"value":24},{"value":13},{"value":8},{"value":7},{"value":3},{"value":0},{"value":2},{"value":1},{"value":0},{"value":0},{"value":2},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":1}]}],"title":{"text":"Distribuição de Gorjetas – NYC Taxi"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["0.00-13.37","13.37-26.73","26.73-40.10","40.10-53.47","53.47-66.83","66.83-80.20","80.20-93.57","93.57-106.93","106.93-120.30","120.30-133.67","133.67-147.03","147.03-160.40","160.40-173.77","173.77-187.13","187.13-200.50","200.50-213.87","213.87-227.23","227.23-240.60","240.60-253.97","253.97-267.33","267.33-280.70","280.70-294.07","294.07-307.43","307.43-320.80","320.80-334.17","334.17-347.53","347.53-360.90","360.90-374.27","374.27-387.63","387.63-401.00"]}],"yAxis":[{}]}
+
+    goecharts_HKzRMOHDyPMP.setOption(option_HKzRMOHDyPMP);
+</script>
+<style>
+    .container {margin-top:30px; display: flex;justify-content: center;align-items: center;}
+    .item {margin: auto;}
+</style>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
             <p class="link-destaque"><a href="iris_pca/index.html">Iris PCA Visualizer</a></p>
             <p class="link-destaque"><a href="docs/b3_prices/index.html">B3 Daily Prices Snapshot</a></p>
             <p class="link-destaque"><a href="docs/sidra_dashboard/index.html">SIDRA Inflation Dashboard</a></p>
+            <p class="link-destaque"><a href="docs/nyc_tips/index.html">NYC Taxi Tip Histogram</a></p>
         </section>
         <section>
             <h2 class="section-title">Estudos prova Seguro Saúde</h2>

--- a/nyc_tips/go.mod
+++ b/nyc_tips/go.mod
@@ -1,0 +1,8 @@
+module nyc_tips
+
+go 1.23.8
+
+require (
+	github.com/go-echarts/go-echarts/v2 v2.6.0
+	gonum.org/v1/gonum v0.16.0
+)

--- a/nyc_tips/go.sum
+++ b/nyc_tips/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-echarts/go-echarts/v2 v2.6.0 h1:4wEquGT/I7lipHnOCh/z3qa8E4dY0SYFdEEnaTzzzvU=
+github.com/go-echarts/go-echarts/v2 v2.6.0/go.mod h1:56YlvzhW/a+du15f3S2qUGNDfKnFOeJSThBIrVFHDtI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
+github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
+gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/nyc_tips/main.go
+++ b/nyc_tips/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/stat"
+
+	"github.com/go-echarts/go-echarts/v2/charts"
+	"github.com/go-echarts/go-echarts/v2/opts"
+)
+
+func main() {
+	url := "https://github.com/DataTalksClub/nyc-tlc-data/releases/download/yellow/yellow_tripdata_2019-01.csv.gz"
+
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatalf("failed to download data: %v", err)
+	}
+	defer resp.Body.Close()
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		log.Fatalf("failed to create gzip reader: %v", err)
+	}
+	defer gz.Close()
+
+	r := csv.NewReader(gz)
+	header, err := r.Read()
+	if err != nil {
+		log.Fatalf("failed reading header: %v", err)
+	}
+
+	idx := -1
+	for i, h := range header {
+		if h == "tip_amount" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		log.Fatalf("tip_amount column not found")
+	}
+
+	var tips []float64
+	maxRows := 1000000
+	for len(tips) < maxRows {
+		rec, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatalf("error reading csv: %v", err)
+		}
+		if idx >= len(rec) {
+			continue
+		}
+		val, err := parseFloat(rec[idx])
+		if err != nil {
+			continue
+		}
+		if math.IsNaN(val) {
+			continue
+		}
+		if val < 0 {
+			val = -val
+		}
+		tips = append(tips, val)
+	}
+
+	if len(tips) == 0 {
+		log.Fatalf("no data read")
+	}
+
+	sort.Float64s(tips)
+
+	bins := 30
+	dividers := make([]float64, bins+1)
+	min := 0.0
+	max := floats.Max(tips) + 1.0
+	floats.Span(dividers, min, max)
+	counts := stat.Histogram(nil, dividers, tips, nil)
+
+	categories := make([]string, bins)
+	for i := 0; i < bins; i++ {
+		categories[i] = fmt.Sprintf("%.2f-%.2f", dividers[i], dividers[i+1])
+	}
+
+	bar := charts.NewBar()
+	bar.SetGlobalOptions(
+		charts.WithInitializationOpts(opts.Initialization{PageTitle: "NYC Taxi Tip Histogram"}),
+		charts.WithTitleOpts(opts.Title{Title: "Distribuição de Gorjetas – NYC Taxi"}),
+	)
+	bar.SetXAxis(categories)
+	data := make([]opts.BarData, bins)
+	for i, c := range counts {
+		data[i] = opts.BarData{Value: c}
+	}
+	bar.AddSeries("Gorjetas", data)
+
+	outDir := "../docs/nyc_tips"
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		log.Fatalf("failed creating output dir: %v", err)
+	}
+	f, err := os.Create(outDir + "/index.html")
+	if err != nil {
+		log.Fatalf("failed creating output file: %v", err)
+	}
+	defer f.Close()
+	if err := bar.Render(f); err != nil {
+		log.Fatalf("failed rendering chart: %v", err)
+	}
+}
+
+func parseFloat(s string) (float64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
+}


### PR DESCRIPTION
## Summary
- add NYC taxi tip histogram Go program
- generate nyc_tips HTML page
- link histogram from Data Science projects section

## Testing
- `go run main.go`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68586712612883309b606fa9f9694075