### PR TITLE
Add CSRF web hacking page

### DIFF
--- a/csrf.html
+++ b/csrf.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>CSRF</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            line-height: 1.6;
+        }
+        h1 {
+            font-size: 28px;
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Cross-Site Request Forgery (CSRF)</h1>
+    <p>CSRF ocorre quando um site malicioso faz com que o navegador de um usuário autenticado execute ações indesejadas em outro site. Como as requisições são enviadas com as credenciais do usuário, a aplicação vulnerável acaba processando-as como se fossem legítimas.</p>
+    <h2>Exemplos notáveis</h2>
+    <ul>
+        <li><strong>2007 – YouTube:</strong> Um ataque permitia postar vídeos sem consentimento do usuário ao explorar formulários sem tokens de verificação.</li>
+        <li><strong>2010 – Gmail:</strong> Pesquisadores demonstraram a alteração de configurações de filtros por meio de requisições forjadas.</li>
+        <li><strong>2014 – Etsy:</strong> Uma falha na função de envio de mensagens permitia que links fossem enviados em nome das vítimas.</li>
+    </ul>
+    <p>Para mitigar CSRF é recomendável utilizar tokens de sessão imprevisíveis, validar a origem das requisições e empregar cabeçalhos como SameSite em cookies.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
             <p class="link-destaque"><a href="dns_poisoning.html">DNS Poisoning</a></p>
             <p class="link-destaque"><a href="idor.html">IDOR</a></p>
             <p class="link-destaque"><a href="ssrf.html">SSRF</a></p>
+            <p class="link-destaque"><a href="csrf.html">CSRF</a></p>
         </section>
         <section>
             <h2 class="section-title">Estudos prova Seguro Saúde</h2>


### PR DESCRIPTION
## Summary
- add CSRF page with explanation and examples
- link CSRF page from the WebHacking/Bug Bounty section of index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68790459e6348330a12d93722ebc7aed