### PR TITLE
Reorganiza projetos de futebol em Projetos Pessoais

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,15 +54,20 @@
     <main>
         <section>
             <h2 class="section-title">Projetos</h2>
-            <p class="link-destaque"><a href="brasileirao_2025.html">Brasileirão 2025</a></p>
             <p class="link-destaque"><a href="pato.html">Foto de um Pato</a></p>
             <p class="link-destaque"><a href="meu_primeiro_dash.html">Meu Primeiro Dashboard</a></p>
-            <p class="link-destaque"><a href="palmeiras_mundial.html">Palmeiras no Mundial 2025</a></p>
             <p class="link-destaque"><a href="about.html">Sobre o Site</a></p>
         </section>
         <section>
-            <h2 class="section-title">Projetos - Data Science</h2>
+            <h2 class="section-title">Projetos Pessoais</h2>
+            <p class="link-destaque"><a href="../brasileirao_2025.html">Brasileirão 2025</a></p>
+            <p class="link-destaque"><a href="../palmeiras_mundial.html">Palmeiras no Mundial 2025</a></p>
             <p class="link-destaque"><a href="worldcup_2026/index.html">Copa do Mundo FIFA 2026</a></p>
+            <p class="link-destaque"><a href="serie_a_2026/index.html">Brasileirão Série A 2026</a></p>
+            <p class="link-destaque"><a href="serie_b_2026/index.html">Brasileirão Série B 2026</a></p>
+        </section>
+        <section>
+            <h2 class="section-title">Projetos - Data Science</h2>
             <p class="link-destaque"><a href="projec-index.html">Mapa de CO2</a></p>
             <p class="link-destaque"><a href="meu_primeiro_dash.html">Meu Primeiro Dashboard</a></p>
             <p class="link-destaque"><a href="iris_pca/index.html">Iris PCA Visualizer</a></p>

--- a/index.html
+++ b/index.html
@@ -54,17 +54,20 @@
     <main>
         <section>
             <h2 class="section-title">Projetos</h2>
-            <p class="link-destaque"><a href="brasileirao_2025.html">Brasileirão 2025</a></p>
             <p class="link-destaque"><a href="pato.html">Foto de um Pato</a></p>
             <p class="link-destaque"><a href="meu_primeiro_dash.html">Meu Primeiro Dashboard</a></p>
-            <p class="link-destaque"><a href="palmeiras_mundial.html">Palmeiras no Mundial 2025</a></p>
             <p class="link-destaque"><a href="about.html">Sobre o Site</a></p>
         </section>
         <section>
-            <h2 class="section-title">Projetos - Data Science</h2>
+            <h2 class="section-title">Projetos Pessoais</h2>
+            <p class="link-destaque"><a href="brasileirao_2025.html">Brasileirão 2025</a></p>
+            <p class="link-destaque"><a href="palmeiras_mundial.html">Palmeiras no Mundial 2025</a></p>
             <p class="link-destaque"><a href="docs/worldcup_2026/index.html">Copa do Mundo FIFA 2026</a></p>
             <p class="link-destaque"><a href="docs/serie_a_2026/index.html">Brasileirão Série A 2026</a></p>
             <p class="link-destaque"><a href="docs/serie_b_2026/index.html">Brasileirão Série B 2026</a></p>
+        </section>
+        <section>
+            <h2 class="section-title">Projetos - Data Science</h2>
             <p class="link-destaque"><a href="projec-index.html">Mapa de CO2</a></p>
             <p class="link-destaque"><a href="meu_primeiro_dash.html">Meu Primeiro Dashboard</a></p>
             <p class="link-destaque"><a href="iris_pca/index.html">Iris PCA Visualizer</a></p>


### PR DESCRIPTION
## Resumo
- cria a seção **Projetos Pessoais** na página principal
- move para ela os projetos Brasileirão 2025, Palmeiras no Mundial 2025, Copa do Mundo FIFA 2026 e Brasileirão Séries A e B 2026
- alinha a navegação em `docs/index.html` e preserva os destinos dos projetos

## Validação
- comparação com `main`: somente `index.html` e `docs/index.html` foram alterados
- os cinco links de futebol aparecem em **Projetos Pessoais** nas duas páginas
- nenhum projeto de futebol permanece em **Projetos - Data Science**

O PR não faz merge automático.