### PR TITLE
Atualiza a seção Sobre com histórico profissional

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,38 +3,41 @@
 <head>
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sobre Felipe Landim | Dados e crédito</title>
-  <meta name="description" content="Conheça a trajetória de Felipe Landim em dados, crédito, produtos financeiros, saúde suplementar e previdência.">
+  <meta name="description" content="Trajetória profissional de Felipe Landim em políticas de crédito, produtos financeiros, dados, saúde suplementar, previdência e atuária.">
   <link rel="canonical" href="https://felandim.github.io/about.html"><link rel="stylesheet" href="style.css">
 </head>
 <body>
   <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
   <header class="site-header"><div class="container nav-wrap"><a class="brand" href="index.html"><span>FL</span> Felipe Landim</a><nav class="site-nav" aria-label="Navegação principal"><a href="projetos.html">Projetos</a><a href="dados-futebol.html">Dados de futebol</a><a href="artigos.html">Artigos</a><a href="about.html" aria-current="page">Sobre</a></nav></div></header>
   <main id="conteudo">
-    <section class="page-hero"><div class="container"><div class="breadcrumb"><a href="index.html">Início</a><span>/</span><span>Sobre</span></div><p class="eyebrow">Sobre</p><h1>Experiência em dados, crédito e produtos financeiros.</h1><p class="lead">Minha trajetória profissional inclui crédito, produtos financeiros, saúde suplementar e previdência, com atuação em analytics, automação e visualização de dados.</p></div></section>
+    <section class="page-hero"><div class="container"><div class="breadcrumb"><a href="index.html">Início</a><span>/</span><span>Sobre</span></div><p class="eyebrow">Sobre</p><h1>Sou Felipe Landim. Trabalho com dados aplicados a crédito.</h1><p class="lead">Comecei na atuária e na previdência, passei por saúde e produto de cartão e hoje atuo com políticas de crédito no banco BV.</p></div></section>
     <section class="page-section"><div class="container about-grid">
       <div class="prose">
         <h2>Perfil</h2>
-        <p>Sou analista de dados e crédito, formado em Ciências Atuariais pela FEA-USP. Trabalho com políticas de crédito, análises de comportamento, automação de rotinas e comunicação executiva.</p>
-        <p>Uso Python e SQL para transformar regras e bases extensas em análises reproduzíveis. Databricks, Power BI e Git completam a rotina quando o problema pede processamento, visualização ou versionamento.</p>
-        <p>Este site reúne apenas projetos públicos. As experiências profissionais aparecem em nível de contexto, sem expor dados, estratégias ou informações confidenciais.</p>
-        <h2>Trajetória</h2>
+        <p>Sou formado em Ciências Atuariais pela FEA-USP e trabalho com dados desde 2020, quase sempre dentro de serviços financeiros.</p>
+        <p>Gosto da parte em que uma regra de negócio, uma base difícil e uma decisão real se encontram. No dia a dia, uso principalmente SQL, Python e Databricks para investigar problemas, acompanhar carteiras e transformar análises em mudanças de política ou produto.</p>
+        <p>Este site é o espaço onde publico projetos pessoais. O conteúdo profissional fica restrito ao contexto das experiências, sem dados ou informações confidenciais das empresas.</p>
+        <h2>Histórico profissional</h2>
         <div class="timeline">
-          <article><h3>Crédito e políticas</h3><p>Atuação atual com estratégias de crédito, elegibilidade, marcações de risco e acompanhamento de resultados.</p></article>
-          <article><h3>Produto financeiro</h3><p>Análises de carteira de cartão, ativação, uso, retenção e oportunidades de crescimento.</p></article>
-          <article><h3>Dados em saúde</h3><p>Construção e validação de painéis, rotinas analíticas e indicadores em saúde suplementar.</p></article>
-          <article><h3>Previdência e automação</h3><p>ETL (extração, transformação e carga), automações operacionais e dashboards para previdência complementar.</p></article>
+          <article><h3>banco BV · Analista de Políticas de Crédito</h3><p><strong>2026 — atual</strong><br>Políticas para cartão de crédito, com análises de elegibilidade, risco e desempenho da carteira.</p></article>
+          <article><h3>will bank · Analista de Crédito</h3><p><strong>2025 — 2026</strong><br>Análises de crédito para cartões, com foco em regras, carteira e inadimplência.</p></article>
+          <article><h3>PicPay · Analista de Produtos</h3><p><strong>2025</strong><br>Acompanhamento da carteira de cartões de pequenos limites, incluindo ativação, uso, retenção e oportunidades de crescimento.</p></article>
+          <article><h3>SulAmérica · Analista de Dados</h3><p><strong>2024 — 2025</strong><br>Construção e validação de indicadores, dashboards e rotinas analíticas para saúde suplementar.</p></article>
+          <article><h3>Fundação Itaú Unibanco · Analista Júnior de Seguridade</h3><p><strong>2021 — 2024</strong><br>Rotinas de previdência complementar, automações com Python e VBA e desenvolvimento de painéis.</p></article>
+          <article><h3>Fundação Itaú Unibanco · Estagiário de Seguridade</h3><p><strong>2021</strong><br>Apoio às rotinas de cadastro, seguridade e atendimento aos planos de previdência.</p></article>
+          <article><h3>Conde Consultoria Atuarial · Auxiliar Técnico Atuarial</h3><p><strong>2020 — 2021</strong><br>Apoio técnico a cálculos e estudos atuariais de previdência.</p></article>
         </div>
       </div>
       <aside class="fact-card">
         <p class="eyebrow">Resumo</p>
         <dl class="fact-list">
-          <div><dt>Atuação</dt><dd>Dados, crédito e produto</dd></div>
+          <div><dt>Atuação atual</dt><dd>Políticas de crédito · banco BV</dd></div>
           <div><dt>Formação</dt><dd>Ciências Atuariais · FEA-USP</dd></div>
           <div><dt>Ferramentas</dt><dd>Python, SQL, Databricks e Power BI</dd></div>
-          <div><dt>Interesses técnicos</dt><dd>Analytics, automação, ML e segurança web</dd></div>
+          <div><dt>Experiência</dt><dd>Crédito, produto, saúde, previdência e atuária</dd></div>
           <div><dt>Localização</dt><dd>São Paulo, Brasil</dd></div>
         </dl>
-        <div class="button-row top-gap"><a class="button button-primary" href="projetos.html">Ver projetos</a><a class="button" href="mailto:landimdb@gmail.com">E-mail</a></div>
+        <div class="button-row top-gap"><a class="button button-primary" href="projetos.html">Ver projetos</a><a class="button" href="https://www.linkedin.com/in/landimfelipe">LinkedIn</a><a class="button" href="mailto:landimdb@gmail.com">E-mail</a></div>
       </aside>
     </div></section>
   </main>


### PR DESCRIPTION
## O que mudou
- substitui o texto genérico por uma apresentação em primeira pessoa;
- adiciona o histórico profissional completo, com empresas, cargos e períodos;
- atualiza o resumo lateral e inclui acesso direto ao LinkedIn;
- mantém apenas informações profissionais públicas e sem dados confidenciais.

## Motivo
A página anterior agrupava a carreira por temas e não mostrava a trajetória real, o que deixava o conteúdo impessoal e pouco verificável.

## Validação
- alteração restrita ao arquivo `about.html`;
- estrutura HTML e classes existentes foram preservadas;
- o branch está um commit à frente de `main`, sem divergências.